### PR TITLE
Allow calling `get-directories` more than once

### DIFF
--- a/crates/wasi/src/preview2/ctx.rs
+++ b/crates/wasi/src/preview2/ctx.rs
@@ -1,10 +1,9 @@
 use super::clocks::host::{monotonic_clock, wall_clock};
 use crate::preview2::{
     bindings::cli::{terminal_input, terminal_output},
-    bindings::filesystem::types::Descriptor,
     bindings::io::streams,
     clocks::{self, HostMonotonicClock, HostWallClock},
-    filesystem::{Dir, TableFsExt},
+    filesystem::Dir,
     pipe, random, stdio,
     stdio::{HostTerminalInputState, HostTerminalOutputState},
     stream::{HostInputStream, HostOutputStream, TableStreamExt},
@@ -317,16 +316,6 @@ impl WasiCtxBuilder {
         let stdout = Some(table.push_output_stream(stdout.0).context("stdout")?);
         let stderr = Some(table.push_output_stream(stderr.0).context("stderr")?);
 
-        let preopens = preopens
-            .into_iter()
-            .map(|(dir, path)| {
-                let dirfd = table
-                    .push_dir(dir)
-                    .with_context(|| format!("preopen {path:?}"))?;
-                Ok((dirfd, path))
-            })
-            .collect::<anyhow::Result<Vec<_>>>()?;
-
         Ok(WasiCtx {
             stdin,
             stdin_terminal,
@@ -362,7 +351,7 @@ pub struct WasiCtx {
     pub(crate) monotonic_clock: Box<dyn HostMonotonicClock + Send + Sync>,
     pub(crate) env: Vec<(String, String)>,
     pub(crate) args: Vec<String>,
-    pub(crate) preopens: Vec<(Resource<Descriptor>, String)>,
+    pub(crate) preopens: Vec<(Dir, String)>,
     pub(crate) stdin: Option<Resource<streams::InputStream>>,
     pub(crate) stdout: Option<Resource<streams::OutputStream>>,
     pub(crate) stderr: Option<Resource<streams::OutputStream>>,

--- a/crates/wasi/src/preview2/filesystem.rs
+++ b/crates/wasi/src/preview2/filesystem.rs
@@ -93,6 +93,7 @@ bitflags::bitflags! {
     }
 }
 
+#[derive(Clone)]
 pub(crate) struct Dir {
     pub dir: Arc<cap_std::fs::Dir>,
     pub perms: DirPerms,


### PR DESCRIPTION
For now `Clone` the directories into new descriptor slots as needed.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
